### PR TITLE
Fix desktop OpenGL on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,10 +32,16 @@ Makefile*
 
 #QtCtreator Qml
 *.qmlproject.user
-*.qmlproject.user.* 
+*.qmlproject.user.*
 
 #Python
 *.pyc
 
 #.desktop
 *.desktop
+
+# qmake
+/release/
+/debug/
+/object_script.*.Debug
+/object_script.*.Release

--- a/main.cpp
+++ b/main.cpp
@@ -18,7 +18,6 @@ int main(int argc, char *argv[])
     // When (un)docking windows, some widgets may get transformed into native
     // widgets, causing painting glitches.  Tell Qt that we prefer non-native.
     QCoreApplication::setAttribute(Qt::AA_DontCreateNativeWidgetSiblings);
-    QCoreApplication::setAttribute(Qt::AA_UseOpenGLES);
     QCoreApplication::setOrganizationDomain("cmdrkotori.mpc-qt");
     QApplication a(argc, argv);
     a.setWindowIcon(QIcon(":/images/bitmaps/icon.png"));


### PR DESCRIPTION
Qt's getProcAddress doesn't work for all core OpenGL functions on Windows, which seems to be the reason why desktop OpenGL wasn't working. This gets it working for me in MSYS2, but I haven't tested it in QtCreator/Qt 5.5.

Also, I added .gitignore entries for some files that MSYS2's qmake created.

Related: mpv-player/mpv-examples#2