### PR TITLE
Fixing fullscreen bottom area behavior

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -68,6 +68,7 @@ private:
     void setupPlaylist();
     void setupStatus();
     void setupSizing();
+    void setupBottomArea();
     void setupHideTimer();
     void connectActionsToSlots();
     void connectButtonsToActions();

--- a/qdrawnslider.cpp
+++ b/qdrawnslider.cpp
@@ -203,6 +203,8 @@ void QDrawnSlider::mouseMoveEvent(QMouseEvent *ev)
         }
     }
     handleHover(ev->localPos().x());
+    // Forward mouse move events also to the parent widget
+    ev->ignore();
 }
 
 


### PR DESCRIPTION
So, after a lot of testing I still encountered a few issues when using the GUI controls in fullscreen mode and tried to fix them.

I don't have much experience with Qt and even much less with C++, so there may be a cleaner way to do this.

### Bug 1
If `ShowWhenHovering` is selected and timeout is > 0 ms, moving the mouse slowly upwards will keep resetting the hideTimer even if the bar is not hovered anymore. I added a check wether the hideTimer is currently active.

### Bug 2
If `ShowWhenMoving` is selected and the bottom area is being hovered, then after the hideTimer triggers the bottomArea will be hidden, however imediately after that mpvw will receive a mousemove event (even if the mouse is not moved) and the bottomArea will be shown again. This causes a few visual bugs. For example the one I already demonstrated in this video in issue #36. ([Video](https://0x0.st/aVB.webm))
Also, the time display in the status bar (Ctrl+5) will disappear.
To fix this, I added a check in the hideTimer_timeout() whether the bottomArea contains the cursor.

### Bug 3
If `ShowWhenHovering` is selected and the playlist widget is shown, then moving the cursor from the bottom bar directly to the playlist widget, the bottom bar does not get hidden, even though it is not hovered anymore. That's because mouse tracking is only enabled on mpvw. For it to work correctly in every situation, I enabled mouse tracking on all widgets of the playlist and the bottomArea and changed checkBottomArea() accordingly, for example to make sure, that moving the mouse over the playlist widgets will not unhide the bottomArea but still starts the hideTimer if it was not done already.

### Other changes
I had to make checkBottomArea() take the global cursor position and map it inside this function to the local position in a context depending on the selected bottomAreaBehavior, to make the contains() functions work, when the playlist is shown and docked on the left side.