### PR TITLE
main,mainwindow,manager,mpvwidget: show bitrate stats

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -136,6 +136,10 @@ Flow::Flow(QObject *owner) :
             mainWindow, &MainWindow::setDisplayFramedrops);
     connect(playbackManager, &PlaybackManager::decoderFramedropsChanged,
             mainWindow, &MainWindow::setDecoderFramedrops);
+    connect(playbackManager, &PlaybackManager::audioBitrateChanged,
+            mainWindow, &MainWindow::setAudioBitrate);
+    connect(playbackManager, &PlaybackManager::videoBitrateChanged,
+            mainWindow, &MainWindow::setVideoBitrate);
 
     // mainwindow -> settings
     connect(mainWindow, &MainWindow::volumeChanged,

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -626,6 +626,13 @@ void MainWindow::updateFramedrops()
                             .arg(decoderDrops > 0 ? decoderDrops : 0));
 }
 
+void MainWindow::updateBitrate()
+{
+    ui->bitrate->setText(QString("v: %1 kb/s, a: %2 kb/s")
+                         .arg(std::lrint(videoBitrate / 1000))
+                         .arg(std::lrint(audioBitrate / 1000)));
+}
+
 void MainWindow::updateSize(bool first_run)
 {
     if (zoomMode == FitToWindow || fullscreenMode() || isMaximized()) {
@@ -970,6 +977,18 @@ void MainWindow::setDecoderFramedrops(int64_t count)
 {
     decoderDrops = count;
     updateFramedrops();
+}
+
+void MainWindow::setAudioBitrate(double bitrate)
+{
+    audioBitrate = bitrate;
+    updateBitrate();
+}
+
+void MainWindow::setVideoBitrate(double bitrate)
+{
+    videoBitrate = bitrate;
+    updateBitrate();
 }
 
 void MainWindow::setPlaylistVisibleState(bool yes) {

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -81,6 +81,7 @@ private:
     void updateBottomAreaGeometry();
     void updateTime();
     void updateFramedrops();
+    void updateBitrate();
     void updatePlaybackStatus();
     void updateSize(bool first_run = false);
     void updateInfostats();
@@ -148,6 +149,8 @@ public slots:
     void setDisplayFramedrops(int64_t count);
     void setDecoderFramedrops(int64_t count);
     void setPlaylistVisibleState(bool yes);
+    void setAudioBitrate(double bitrate);
+    void setVideoBitrate(double bitrate);
 
 private slots:
     void on_actionFileOpenQuick_triggered();
@@ -258,6 +261,8 @@ private:
     bool zoomCenter;
     int64_t displayDrops;
     int64_t decoderDrops;
+    double audioBitrate;
+    double videoBitrate;
 
     MouseStateMap mouseMapWindowed;
     MouseStateMap mouseMapFullscreen;

--- a/manager.cpp
+++ b/manager.cpp
@@ -53,6 +53,10 @@ void PlaybackManager::setMpvWidget(MpvWidget *mpvWidget, bool makeConnections)
                 this, &PlaybackManager::mpvw_metadataChanged);
         connect(mpvWidget, &MpvWidget::playlistChanged,
                 this, &PlaybackManager::mpvw_playlistChanged);
+        connect(mpvWidget, &MpvWidget::audioBitrateChanged,
+                this, &PlaybackManager::mpvw_audioBitrateChanged);
+        connect(mpvWidget, &MpvWidget::videoBitrateChanged,
+                this, &PlaybackManager::mpvw_videoBitrateChanged);
 
         connect(this, &PlaybackManager::hasNoVideo,
                 mpvWidget, &MpvWidget::setDrawLogo);
@@ -511,6 +515,16 @@ void PlaybackManager::mpvw_displayFramedropsChanged(int64_t count)
 void PlaybackManager::mpvw_decoderFramedropsChanged(int64_t count)
 {
     emit decoderFramedropsChanged(count);
+}
+
+void PlaybackManager::mpvw_audioBitrateChanged(double bitrate)
+{
+    emit audioBitrateChanged(bitrate);
+}
+
+void PlaybackManager::mpvw_videoBitrateChanged(double bitrate)
+{
+    emit videoBitrateChanged(bitrate);
 }
 
 void PlaybackManager::mpvw_metadataChanged(QVariantMap metadata)

--- a/manager.h
+++ b/manager.h
@@ -92,6 +92,8 @@ private slots:
     void mpvw_decoderFramedropsChanged(int64_t count);
     void mpvw_metadataChanged(QVariantMap metadata);
     void mpvw_playlistChanged(const QVariantList &playlist);
+    void mpvw_audioBitrateChanged(double bitrate);
+    void mpvw_videoBitrateChanged(double bitrate);
 
 signals:
     void playerSettingsRequested();
@@ -117,6 +119,8 @@ signals:
     void avsyncChanged(double sync);
     void displayFramedropsChanged(int64_t count);
     void decoderFramedropsChanged(int64_t count);
+    void audioBitrateChanged(double bitrate);
+    void videoBitrateChanged(double bitrate);
 
 private:
     MpvWidget *mpvWidget_;

--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -601,6 +601,8 @@ void MpvWidget::ctrl_mpvPropertyChanged(QString name, QVariant v)
     HANDLE_PROP_1("avsync", avsyncChanged, toDouble, 0.0);
     HANDLE_PROP_1("vo-drop-frame-count", displayFramedropsChanged, toLongLong, 0ll);
     HANDLE_PROP_1("drop-frame-count", decoderFramedropsChanged, toLongLong, 0ll);
+    HANDLE_PROP_1("audio-bitrate", audioBitrateChanged, toDouble, 0.0);
+    HANDLE_PROP_1("video-bitrate", videoBitrateChanged, toDouble, 0.0);
     HANDLE_PROP_1("metadata", self_metadata, toMap, QVariantMap());
 }
 

--- a/mpvwidget.h
+++ b/mpvwidget.h
@@ -108,6 +108,8 @@ signals:
     void avsyncChanged(double sync);
     void displayFramedropsChanged(int64_t count);
     void decoderFramedropsChanged(int64_t cout);
+    void audioBitrateChanged(double bitrate);
+    void videoBitrateChanged(double bitrate);
     void playlistChanged(QVariantList playlist);
 
     void logoSizeChanged(QSize size);


### PR DESCRIPTION
So I was wondering, why the bitrate stats always showed 0, and whether it was a mpv bug. But it turned out even though the code watched the bitrate properties, they weren't passed down to the UI. And when I added the code for it, it turned out mpv actually had a bug and didn't update observed bitrate properties, so this requires a newer mpv build (see https://github.com/mpv-player/mpv/commit/d080851a3049174fc8a329f5930bc46272b448dc).