### PR TITLE
ipc: add an "append" parameter for appending files to playlist

### DIFF
--- a/DOCS/ipc.md
+++ b/DOCS/ipc.md
@@ -23,7 +23,9 @@ The *playFiles* command takes the extra parameter `files` (an array) and
 optionally `directory` (a string).  It processes the given filenames relative
 to the specified directory if provided, and processes it in the same manner as
 `File -> Quick Open`.  This command was designed for passing files specified
-on the command line through to an already-running process.
+on the command line through to an already-running process. If a parameter
+`append` (a boolean) with the value `true` is provided, then the command
+behaves the same as `File -> Quick Add To Playlist`.
 
 The *pause* command pauses the current playback.  If nothing is being played,
 nothing happens.

--- a/ipc.cpp
+++ b/ipc.cpp
@@ -170,13 +170,14 @@ void MpcQtServer::ipc_playFiles(const QVariantMap &map)
 {
     QString workingDirectory = map["directory"].toString();
     QStringList filesAsText = map["files"].toStringList();
+    bool important = !map.value("append", false).toBool();
     QList<QUrl> files;
     QUrl url;
     foreach (QString s, filesAsText) {
         files << QUrl::fromUserInput(s, workingDirectory);
     }
     if (!files.empty()) {
-        playbackManager->openSeveralFiles(files, true);
+        playbackManager->openSeveralFiles(files, important);
     }
 }
 


### PR DESCRIPTION
You don't want to always overwrite the current playlist.

-----------------

Making this a parameter to the existing command seemed most natural.