### PR TITLE
Mpris position must be in microseconds

### DIFF
--- a/ipcmpris.cpp
+++ b/ipcmpris.cpp
@@ -238,7 +238,7 @@ void MprisPlayerServer::setVolume(double volume)
 
 qlonglong MprisPlayerServer::position()
 {
-    return qlonglong(playbackTime_ * 1000);
+    return qlonglong(playbackTime_ * 1000000);
 }
 
 double MprisPlayerServer::minimumRate()


### PR DESCRIPTION
Per https://specifications.freedesktop.org/mpris-spec/2.2/Player_Interface.html#Property:Position, the reported position must be specified in microseconds, not milliseconds.

Both the Seek and SetPosition methods do this correctly.

Initially reported in https://github.com/FichteFoll/discordrp-mpris/issues/6.