### PR TITLE
Add Travis support to automatically build binaries for macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,14 @@ script:
 - make -j2
 - make install
 - macdeployqt mpc-qt.app -libpath=/usr/local/lib/
-- python macdeployqtfix/macdeployqtfix.py mpc-qt.app/Contents/MacOS/mpc-qt /usr/local/Cellar/qt/5.11.2_1/ -v
+- python macdeployqtfix/macdeployqtfix.py mpc-qt.app/Contents/MacOS/mpc-qt $(pkg-config --variable=prefix Qt5Gui) -v
 
 before_install:
 - brew update
 - cd $(brew --repo homebrew/core)
 - git checkout 5eb54ced793999e3dd3bce7c64c34e7ffe65ddfd
 - cd $TRAVIS_BUILD_DIR
+- brew install pkgconfig
 - brew install mpv
 - brew install qt
 - brew link qt --force
@@ -24,7 +25,7 @@ before_install:
 
 install:
 - git clone --branch v0.29.1 https://github.com/mpv-player/mpv.git
-- cp mpv/libmpv/* /usr/local/Cellar/mpv/0.29.1_1/include/mpv/
+- cp mpv/libmpv/* $(pkg-config --variable=includedir mpv)/mpv/
 - rm -rf mpv
 - git clone https://github.com/arl/macdeployqtfix.git
 - git fetch --unshallow

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
 - brew install mpv
 - brew install qt
 - brew link qt --force
+- brew install librsvg
 
 install:
 - git clone --branch v0.29.1 https://github.com/mpv-player/mpv.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
 - make -j2
 - make install
 - macdeployqt mpc-qt.app -libpath=/usr/local/lib/
-- python macdeployqtfix/macdeployqtfix.py mpc-qt.app/Contents/MacOS/mpc-qt /usr/local/Cellar/qt/5.11.2/ -v
+- python macdeployqtfix/macdeployqtfix.py mpc-qt.app/Contents/MacOS/mpc-qt /usr/local/Cellar/qt/5.11.2_1/ -v
 
 before_install:
 - brew update

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
 - qmake mpc-qt.pro
 - make -j2
 - make install
-- macdeployqt mpc-qt.app -libpath=/usr/local/lib/
+- macdeployqt mpc-qt.app -libpath=/usr/local/lib/ -libpath=$(pkg-config --variable=prefix Qt5Gui)/Frameworks/
 - python macdeployqtfix/macdeployqtfix.py mpc-qt.app/Contents/MacOS/mpc-qt $(pkg-config --variable=prefix Qt5Gui) -v
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ install:
 
 before_deploy:
 - ls -al
-- brew upgrade python
 - pip install dmgbuild
 - dmgbuild -s make-release-mac.py "mpc-qt" mpc-qt.dmg
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ script:
 
 before_install:
 - brew update
+- cd $(brew --repo homebrew/core)
+- git checkout 5eb54ced793999e3dd3bce7c64c34e7ffe65ddfd
+- cd $TRAVIS_BUILD_DIR
 - brew install mpv
 - brew install qt
 - brew link qt --force

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+language: objective-c
+osx_image: xcode9.2
+
+branches:
+  only:
+  - travis
+
+script:
+- qmake
+- make -j2
+- make install
+- macdeployqt mpc-qt.app -libpath=/usr/local/lib/
+- python ../macdeployqtfix/macdeployqtfix.py mpc-qt.app/Contents/MacOS/mpc-qt /usr/local/Cellar/qt/5.11.2/ -v
+
+
+before_install:
+- brew update
+- brew install mpv
+- brew install qt
+- brew link qt --force
+
+install:
+- git clone --branch v0.29.1 https://github.com/mpv-player/mpv.git
+- cp mpv/libmpv/* /usr/local/Cellar/mpv/0.29.1/include/mpv/
+- rm -rf mpv
+- git clone https://github.com/arl/macdeployqtfix.git
+
+before_deploy:
+- ls -al
+- zip -r mpc-qt.zip mpc-qt.app
+- cd ..
+
+deploy:
+  skip_cleanup: true
+  on: travis
+  provider: bintray
+  file: "bintray.json"
+  user: alby128
+  key:
+    secure: "h1ZKUCkLilR6NDlrF73g1GHFFVCN2F8dDBnJNwiYaUPZT4znToZwZE8Qh2ukLaz2jjIr2d6fxN+jV1TLJPjq5v7HRsXEJZjy64Fp0OniO3SGpzEvnQZL+58RUwmQU0Y+VeBbDLmyu5wNrLbmXZnjeK1OcJYM1CV6qxHP+uQA5QCxkCqa4/MP5/rmpTRNu/iz0zQD1qSrqf0q61xCG+aJCnX6JhQvs4w1UXdU4Qy53OfAeI1kDq7Fwpoa+AxOMfXvnIy9Yo0igdi64s8e8klv+uaqJ/TvslFDslqbivNOZuXv1+wZCq+ac4npPtDMQZyWoBvMZ0U24LJ3e24en2OsRcQBXdaiTS1r4PAstVn7VjFWgbgzgGTBSKlqucGgxg0O3RsX+GiG1yHjsIJ9JF9AtBn9Awcy5NMJsOi9meLN+AgEOVtMIEVWDH8m5jMK+aCHYsm7tEBYcjFpTaYl3/t9EaPeqjKpOvUNSJDTfSnsuIXKp233GIiIDWbMXzLWCR8F1Ijk9FNTJqtJECpBpZOUiHkPN95NPxz98w0CW6rDYjJmZImNYpgflSQ4gzH2w3bfqgvJJqbrsa1imZqMzH+JrmlUFfmZAwNfPJOrKJbSUsZisH8CNvL4x4wHt7iOhZSsT6nO8idkDP0ukKpXJ0qbKluU2Fqfvl1nNIxRYFFkyQs="

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
 
 install:
 - git clone --branch v0.29.1 https://github.com/mpv-player/mpv.git
-- cp mpv/libmpv/* /usr/local/Cellar/mpv/0.29.1/include/mpv/
+- cp mpv/libmpv/* /usr/local/Cellar/mpv/0.29.1_1/include/mpv/
 - rm -rf mpv
 - git clone https://github.com/arl/macdeployqtfix.git
 - git fetch --unshallow

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,7 @@ install:
 
 before_deploy:
 - ls -al
-- curl https://bootstrap.pypa.io/get-pip.py | python
-- pip install dmgbuild
+- pip3 install dmgbuild
 - dmgbuild -s make-release-mac.py "mpc-qt" mpc-qt.dmg
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ script:
 
 before_install:
 - brew update
-- cd $(brew --repo homebrew/core)
-- git checkout 5eb54ced793999e3dd3bce7c64c34e7ffe65ddfd
-- cd $TRAVIS_BUILD_DIR
 - brew install pkgconfig
 - brew install mpv
 - brew install qt

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ install:
 - rm -rf mpv
 - git clone https://github.com/arl/macdeployqtfix.git
 - git fetch --unshallow
+- ln -s /usr/local/opt/python/Frameworks/Python.framework /usr/local/opt/python/lib/
 
 before_deploy:
 - ls -al

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
 
 before_deploy:
 - ls -al
+- curl https://bootstrap.pypa.io/get-pip.py | python
 - pip install dmgbuild
 - dmgbuild -s make-release-mac.py "mpc-qt" mpc-qt.dmg
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,11 @@ branches:
   - travis
 
 script:
-- qmake
+- qmake mpc-qt.pro
 - make -j2
 - make install
 - macdeployqt mpc-qt.app -libpath=/usr/local/lib/
-- python ../macdeployqtfix/macdeployqtfix.py mpc-qt.app/Contents/MacOS/mpc-qt /usr/local/Cellar/qt/5.11.2/ -v
-
+- python macdeployqtfix/macdeployqtfix.py mpc-qt.app/Contents/MacOS/mpc-qt /usr/local/Cellar/qt/5.11.2/ -v
 
 before_install:
 - brew update
@@ -24,11 +23,11 @@ install:
 - cp mpv/libmpv/* /usr/local/Cellar/mpv/0.29.1/include/mpv/
 - rm -rf mpv
 - git clone https://github.com/arl/macdeployqtfix.git
+- git fetch --unshallow
 
 before_deploy:
 - ls -al
 - zip -r mpc-qt.zip mpc-qt.app
-- cd ..
 
 deploy:
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,8 @@ install:
 
 before_deploy:
 - ls -al
-- zip -r mpc-qt.zip mpc-qt.app
+- pip install dmgbuild
+- dmgbuild -s make-release-mac.py "mpc-qt" mpc-qt.dmg
 
 deploy:
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ install:
 
 before_deploy:
 - ls -al
+- brew upgrade python
 - pip install dmgbuild
 - dmgbuild -s make-release-mac.py "mpc-qt" mpc-qt.dmg
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ osx_image: xcode9.2
 
 branches:
   only:
-  - travis
+  - master
 
 script:
 - qmake mpc-qt.pro
@@ -34,7 +34,7 @@ before_deploy:
 
 deploy:
   skip_cleanup: true
-  on: travis
+  on: master
   provider: bintray
   file: "bintray.json"
   user: alby128

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
 - qmake mpc-qt.pro
 - make -j2
 - make install
-- macdeployqt mpc-qt.app -libpath=/usr/local/lib/ -libpath=$(pkg-config --variable=prefix Qt5Gui)/Frameworks/
+- macdeployqt mpc-qt.app -libpath=/usr/local/lib/
 - python macdeployqtfix/macdeployqtfix.py mpc-qt.app/Contents/MacOS/mpc-qt $(pkg-config --variable=prefix Qt5Gui) -v
 
 before_install:

--- a/bintray.json
+++ b/bintray.json
@@ -1,0 +1,20 @@
+{
+    "package": {
+        "name": "mpc-qt",
+        "repo": "mpc-qt",
+        "subject": "alby128"
+    },
+    "version": {
+        "name": "v18.08"
+    },
+    "files": [
+        {
+            "includePattern": "(*\.zip)",
+            "uploadPattern": "$1",
+            "matrixParams": {
+                "override": 1
+            }
+        }
+    ],
+    "publish": true
+}

--- a/bintray.json
+++ b/bintray.json
@@ -9,7 +9,7 @@
     },
     "files": [
         {
-            "includePattern": "./(.*\\.zip)",
+            "includePattern": "./(.*\\.dmg)",
             "uploadPattern": "$1",
             "matrixParams": {
                 "override": 1

--- a/bintray.json
+++ b/bintray.json
@@ -9,7 +9,7 @@
     },
     "files": [
         {
-            "includePattern": "(*\.zip)",
+            "includePattern": "./(.*\\.zip)",
             "uploadPattern": "$1",
             "matrixParams": {
                 "override": 1

--- a/make-mac-icon.sh
+++ b/make-mac-icon.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+if [ ! -f images/icon/mpc-qt.icns ]; then
+    cd images/icon
+	mkdir mpc-qt.iconset
+    rsvg-convert -h 16 mpc-qt.svg > mpc-qt.iconset/icon_16x16.png
+    rsvg-convert -h 32 mpc-qt.svg > mpc-qt.iconset/icon_16x16@2x.png
+    rsvg-convert -h 32 mpc-qt.svg > mpc-qt.iconset/icon_32x32.png
+    rsvg-convert -h 64 mpc-qt.svg > mpc-qt.iconset/icon_32x32@2x.png
+    rsvg-convert -h 128 mpc-qt.svg > mpc-qt.iconset/icon_128x128.png
+    rsvg-convert -h 256 mpc-qt.svg > mpc-qt.iconset/icon_128x128@2x.png
+    rsvg-convert -h 256 mpc-qt.svg > mpc-qt.iconset/icon_256x256.png
+    rsvg-convert -h 512 mpc-qt.svg > mpc-qt.iconset/icon_256x256@2x.png
+    rsvg-convert -h 512 mpc-qt.svg > mpc-qt.iconset/icon_512x512.png
+    rsvg-convert -h 1024 mpc-qt.svg > mpc-qt.iconset/icon_512x512@2x.png
+    iconutil -c icns mpc-qt.iconset
+    rm -R mpc-qt.iconset
+    cd ../..
+fi

--- a/make-release-mac.py
+++ b/make-release-mac.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+
+
+import biplist
+import os.path
+
+application = defines.get('app', 'mpc-qt.app')
+appname = os.path.basename(application)
+
+
+def icon_from_app(app_path):
+    plist_path = os.path.join(app_path, 'Contents', 'Info.plist')
+    plist = biplist.readPlist(plist_path)
+    icon_name = plist['CFBundleIconFile']
+    icon_root, icon_ext = os.path.splitext(icon_name)
+    if not icon_ext:
+        icon_ext = '.icns'
+    icon_name = icon_root + icon_ext
+    return os.path.join(app_path, 'Contents', 'Resources', icon_name)
+
+
+# Volume format (see hdiutil create -help)
+format = defines.get('format', 'UDZO')
+
+# Compression level (if relevant)
+compression_level = 9
+
+# Volume size
+size = defines.get('size', None)
+
+# Files to include
+files = [
+    application
+]
+
+# Symlinks to create
+symlinks = {
+    'Applications': '/Applications'
+}
+
+# Volume icon
+#
+# You can either define icon, in which case that icon file will be copied to the
+# image, *or* you can define badge_icon, in which case the icon file you specify
+# will be used to badge the system's Removable Disk icon
+#
+# icon = '/path/to/icon.icns'
+badge_icon = icon_from_app(application)
+
+# Where to put the icons
+icon_locations = {
+    appname: (125, 100),
+    'Applications': (325, 100)
+}
+
+# .. Window configuration ......................................................
+
+# Background
+#
+# This is a STRING containing any of the following:
+#
+#    #3344ff          - web-style RGB color
+#    #34f             - web-style RGB color, short form (#34f == #3344ff)
+#    rgb(1,0,0)       - RGB color, each value is between 0 and 1
+#    hsl(120,1,.5)    - HSL (hue saturation lightness) color
+#    hwb(300,0,0)     - HWB (hue whiteness blackness) color
+#    cmyk(0,1,0,0)    - CMYK color
+#    goldenrod        - X11/SVG named color
+#    builtin-arrow    - A simple built-in background with a blue arrow
+#    /foo/bar/baz.png - The path to an image file
+#
+# The hue component in hsl() and hwb() may include a unit; it defaults to
+# degrees ('deg'), but also supports radians ('rad') and gradians ('grad'
+# or 'gon').
+#
+# Other color components may be expressed either in the range 0 to 1, or
+# as percentages (e.g. 60% is equivalent to 0.6).
+background = '#c0c0c0'
+
+show_status_bar = False
+show_tab_view = False
+show_toolbar = False
+show_pathbar = False
+show_sidebar = False
+sidebar_width = 180
+
+# Window position in ((x, y), (w, h)) format
+window_rect = ((100, 100), (450, 200))
+
+# Select the default view; must be one of
+#
+#    'icon-view'
+#    'list-view'
+#    'column-view'
+#    'coverflow'
+#
+default_view = 'icon-view'
+
+# General view configuration
+show_icon_preview = False
+
+# Set these to True to force inclusion of icon/list view settings (otherwise
+# we only include settings for the default view)
+include_icon_view_settings = 'auto'
+include_list_view_settings = 'auto'
+
+# .. Icon view configuration ...................................................
+
+arrange_by = None
+grid_offset = (0, 0)
+grid_spacing = 20
+scroll_position = (0, 0)
+label_pos = 'bottom'  # or 'right'
+text_size = 12
+icon_size = 80
+
+# .. List view configuration ...................................................
+
+# Column names are as follows:
+#
+#   name
+#   date-modified
+#   date-created
+#   date-added
+#   date-last-opened
+#   size
+#   kind
+#   label
+#   version
+#   comments
+#
+list_icon_size = 16
+list_text_size = 12
+list_scroll_position = (0, 0)
+list_sort_by = 'name'
+list_use_relative_dates = True
+list_calculate_all_sizes = False,
+list_columns = ('name', 'date-modified', 'size', 'kind', 'date-added')
+list_column_widths = {
+    'name': 300,
+    'date-modified': 181,
+    'date-created': 181,
+    'date-added': 181,
+    'date-last-opened': 181,
+    'size': 97,
+    'kind': 115,
+    'label': 100,
+    'version': 75,
+    'comments': 300,
+    }
+list_column_sort_directions = {
+    'name': 'ascending',
+    'date-modified': 'descending',
+    'date-created': 'descending',
+    'date-added': 'descending',
+    'date-last-opened': 'descending',
+    'size': 'descending',
+    'kind': 'ascending',
+    'label': 'ascending',
+    'version': 'ascending',
+    'comments': 'ascending',
+    }

--- a/mpc-qt.pro
+++ b/mpc-qt.pro
@@ -145,6 +145,7 @@ macx:SOURCES += platform/screensaver_mac.cpp \
                 platform/devicemanager_mac.cpp
 macx:HEADERS += platform/screensaver_mac.h \
                 platform/devicemanager_mac.h
+macx:QT += svg
 
 SOURCES += main.cpp\
     mpvwidget.cpp \

--- a/mpc-qt.pro
+++ b/mpc-qt.pro
@@ -139,6 +139,8 @@ win32:SOURCES += platform/screensaver_win.cpp \
 win32:HEADERS += platform/screensaver_win.h \
                  platform/devicemanager_win.h
 
+macx:RC_ICONS = $$system(./make-mac-icon.sh)
+macx:ICON = images/icon/mpc-qt.icns
 macx:SOURCES += platform/screensaver_mac.cpp \
                 platform/devicemanager_mac.cpp
 macx:HEADERS += platform/screensaver_mac.h \


### PR DESCRIPTION
This PR adds support for Travis CI to automatically generate and deploy a distributable packed version of `mpc-qt` that works on macOS 10.12+ (following the discussion in issue #169). 

A few things and comments:
- Travis CI will start building and deploying automatically once a commit is pushed on master
- the current script embeds `qt 5.11.2` and `mpv 0.29.1` . The script will have to be adjusted when `mpc-qt` will require newer versions of these libraries.
- at this moment, deployment will not work because its target was set to my Bintray account for tests. @cmdrkotori you should pick a deployment target supported by Travis from [here](https://docs.travis-ci.com/user/deployment/) to make the CI upload the distributable archive (.dmg) somewhere. Once you choose one, I can help you update the script accordingly, if necessary.
- there's a minor issue with keyboard shortcuts on macOS that should probably be addressed before merging this (see #236 for further details)

A few screens of the result on macOS 10.13:
![screen shot 2019-01-28 at 19 38 51](https://user-images.githubusercontent.com/7440277/51859057-8b131300-2336-11e9-82e9-a9f8fde5ae91.png)
The as-built app.

![screen shot 2019-01-28 at 19 39 08](https://user-images.githubusercontent.com/7440277/51859065-8e0e0380-2336-11e9-90f6-4efc787bc057.png)
A picture of the opened .dmg archive that should be distributed to users.

